### PR TITLE
Add dockerized Apache Storm

### DIFF
--- a/storm/Dockerfile
+++ b/storm/Dockerfile
@@ -1,0 +1,67 @@
+FROM phusion/baseimage
+
+# Install required packages
+
+RUN apt-get update && \
+    apt-get install -y build-essential && \
+    apt-get install -y software-properties-common python-software-properties && \
+    apt-get install -y python && \
+    apt-get install -y wget
+
+# Install Java.
+
+RUN \
+  add-apt-repository -y ppa:webupd8team/java && \
+  apt-get update && \
+  apt-get install -y openjdk-8-jdk && \
+  rm -rf /var/lib/apt/lists/* && \
+  rm -rf /var/cache/oracle-jdk8-installer
+
+ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk-amd64
+ENV JAVAHOME /usr/lib/jvm/java-1.8.0-openjdk-amd64
+
+# Install Storm.
+
+ENV STORM_USER=platform \
+    STORM_CONF_DIR=/conf \
+    STORM_DATA_DIR=/data \
+    STORM_LOG_DIR=/logs
+
+# Add a user and make dirs
+RUN set -ex; \
+    adduser "$STORM_USER"; \
+    mkdir -p "$STORM_CONF_DIR" "$STORM_DATA_DIR" "$STORM_LOG_DIR"; \
+    chown -R "$STORM_USER:$STORM_USER" "$STORM_CONF_DIR" "$STORM_DATA_DIR" "$STORM_LOG_DIR"``
+
+# Apache Storm distribution version
+ARG DISTRO_NAME=apache-storm-0.10.0
+
+# Download Apache Storm.
+RUN set -ex; \
+    wget -q "http://archive.apache.org/dist/storm/$DISTRO_NAME/$DISTRO_NAME.tar.gz"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    tar -xzf "$DISTRO_NAME.tar.gz"; \
+    chown -R "$STORM_USER:$STORM_USER" "$DISTRO_NAME"; \
+    rm "$DISTRO_NAME.tar.gz";
+
+ENV PATH $PATH:/$DISTRO_NAME/bin
+
+# Copy storm configuration files to image
+ADD storm.yaml /conf
+
+RUN chown -R "$STORM_USER" "$STORM_CONF_DIR" "$STORM_DATA_DIR" "$STORM_LOG_DIR"
+
+# Install Maven.
+ENV MAVEN_VERSION="3.5.4" \
+    M2_HOME=/usr/lib/mvn
+
+RUN cd /tmp && \
+    wget "http://www-us.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" && \
+    tar -zxvf "apache-maven-$MAVEN_VERSION-bin.tar.gz" && \
+    mv "apache-maven-$MAVEN_VERSION" "$M2_HOME" && \
+    ln -s "$M2_HOME/bin/mvn" /usr/bin/mvn && \
+    rm -R /tmp/*
+
+RUN mkdir /project
+
+WORKDIR /project

--- a/storm/Dockerfile
+++ b/storm/Dockerfile
@@ -1,22 +1,10 @@
 FROM drrzmr/java:8.0.201-2
 
-# Install Storm.
-ENV STORM_USER=platform \
-    STORM_CONF_DIR=/conf \
-    STORM_DATA_DIR=/data \
-    STORM_LOG_DIR=/logs
-
 ENV JAVA_HOME=/opt/sdkman/candidates/java/current
 
 RUN apt-get update &&\
     apt-get install -y python &&\
     apt-get autoclean
-
-# Add a user and make dirs
-RUN set -ex; \
-    adduser "$STORM_USER"; \
-    mkdir -p "$STORM_CONF_DIR" "$STORM_DATA_DIR" "$STORM_LOG_DIR"; \
-    chown -R "$STORM_USER:$STORM_USER" "$STORM_CONF_DIR" "$STORM_DATA_DIR" "$STORM_LOG_DIR"``
 
 # Apache Storm distribution version
 ARG STORM_VERSION=0.10.0
@@ -30,9 +18,6 @@ ENV PATH $PATH:/opt/apache-storm-$STORM_VERSION/bin
 # Copy storm configuration files to image
 ADD storm.yaml /conf
 
-RUN chown -R "$STORM_USER" "$STORM_CONF_DIR" "$STORM_DATA_DIR" "$STORM_LOG_DIR"
-
-# Install Maven.
 RUN mkdir /project
 
 EXPOSE 8080/tcp

--- a/storm/Dockerfile
+++ b/storm/Dockerfile
@@ -1,31 +1,16 @@
-FROM phusion/baseimage
-
-# Install required packages
-
-RUN apt-get update && \
-    apt-get install -y build-essential && \
-    apt-get install -y software-properties-common python-software-properties && \
-    apt-get install -y python && \
-    apt-get install -y wget
-
-# Install Java.
-
-RUN \
-  add-apt-repository -y ppa:webupd8team/java && \
-  apt-get update && \
-  apt-get install -y openjdk-8-jdk && \
-  rm -rf /var/lib/apt/lists/* && \
-  rm -rf /var/cache/oracle-jdk8-installer
-
-ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk-amd64
-ENV JAVAHOME /usr/lib/jvm/java-1.8.0-openjdk-amd64
+FROM drrzmr/java:8.0.201-2
 
 # Install Storm.
-
 ENV STORM_USER=platform \
     STORM_CONF_DIR=/conf \
     STORM_DATA_DIR=/data \
     STORM_LOG_DIR=/logs
+
+ENV JAVA_HOME=/opt/sdkman/candidates/java/current
+
+RUN apt-get update &&\
+    apt-get install -y python &&\
+    apt-get autoclean
 
 # Add a user and make dirs
 RUN set -ex; \
@@ -34,17 +19,13 @@ RUN set -ex; \
     chown -R "$STORM_USER:$STORM_USER" "$STORM_CONF_DIR" "$STORM_DATA_DIR" "$STORM_LOG_DIR"``
 
 # Apache Storm distribution version
-ARG DISTRO_NAME=apache-storm-0.10.0
+ARG STORM_VERSION=0.10.0
 
-# Download Apache Storm.
-RUN set -ex; \
-    wget -q "http://archive.apache.org/dist/storm/$DISTRO_NAME/$DISTRO_NAME.tar.gz"; \
-    export GNUPGHOME="$(mktemp -d)"; \
-    tar -xzf "$DISTRO_NAME.tar.gz"; \
-    chown -R "$STORM_USER:$STORM_USER" "$DISTRO_NAME"; \
-    rm "$DISTRO_NAME.tar.gz";
+RUN set -eux; \
+    curl -s "http://archive.apache.org/dist/storm/apache-storm-$STORM_VERSION/apache-storm-$STORM_VERSION.tar.gz" | tar zxC /opt; \
+    ln -s /opt/apache-storm-${STORM_VERSION} /opt/storm
 
-ENV PATH $PATH:/$DISTRO_NAME/bin
+ENV PATH $PATH:/opt/apache-storm-$STORM_VERSION/bin
 
 # Copy storm configuration files to image
 ADD storm.yaml /conf
@@ -52,16 +33,8 @@ ADD storm.yaml /conf
 RUN chown -R "$STORM_USER" "$STORM_CONF_DIR" "$STORM_DATA_DIR" "$STORM_LOG_DIR"
 
 # Install Maven.
-ENV MAVEN_VERSION="3.5.4" \
-    M2_HOME=/usr/lib/mvn
-
-RUN cd /tmp && \
-    wget "http://www-us.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" && \
-    tar -zxvf "apache-maven-$MAVEN_VERSION-bin.tar.gz" && \
-    mv "apache-maven-$MAVEN_VERSION" "$M2_HOME" && \
-    ln -s "$M2_HOME/bin/mvn" /usr/bin/mvn && \
-    rm -R /tmp/*
-
 RUN mkdir /project
+
+EXPOSE 8080/tcp
 
 WORKDIR /project

--- a/storm/storm.yaml
+++ b/storm/storm.yaml
@@ -1,0 +1,23 @@
+# List of the hosts in the Zookeeper cluster.
+# 'zookeeper' is the Docker Compose network reference.
+storm.zookeeper.servers:
+  - "localhost"
+
+storm.zookeeper.port: 2181
+
+# The worker nodes need to know which machines are the 
+# candidate of master in order to download topology jars and confs.
+# If you want to set up Nimbus highly available, 
+# you have to address all machines' FQDN which run nimbus. 
+nimbus.seeds : ["localhost"]
+
+# For each worker machine, you configure how many workers run on that 
+# machine with this config. Each worker uses a single port for receiving 
+# messages, and this setting defines which ports are open for use. 
+# If you define five ports here, then Storm will allocate up to five workers 
+# to run on this machine.
+supervisor.slots.ports:
+    - 6700
+    - 6701
+    - 6702
+    - 6703


### PR DESCRIPTION
Adding the dockerized Apache Storm image version 0.10.0, the same version used in production on our services.

It's packed alongside a configuration file.